### PR TITLE
Fix eternal xkcd ferrets

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -4,6 +4,7 @@ const hangman = require('./misc-commands/hangman');
 const tag = require('./misc-commands/tag')
 const events = require('./utility-commands/events');
 const tracking = require('./misc-commands/tracking');
+const { xkcd } = require('./misc-commands/xkcd');
 
 const commands = {
 	'cooldudes': misc.meme,
@@ -49,7 +50,7 @@ const commands = {
 	'banish': base.banish,
 	'shadowban': base.banish,
 	'unbanish': base.unbanish,
-	'xkcd': misc.xkcd,
+	'xkcd': xkcd,
 	'event': events.event,
 	'tag': tag.tag,
 	'untag': tag.untag,

--- a/misc-commands/misc.js
+++ b/misc-commands/misc.js
@@ -1,6 +1,5 @@
 const axios = require('axios').default;
 const { exec } = require('child_process');
-const querystring = require('querystring');
 const fs = require("fs");
 const tmp = require('tmp-promise');
 const base = require('../base-commands/base');
@@ -303,105 +302,6 @@ const stopListening = (context) => {
 	}
 }
 
-const getXkcdComicInfo = async (num, context) => {
-  if (num !== "") {
-		num = parseInt(num)
-	}
-	const response = await axios.get(`https://xkcd.com/${num}/info.0.json`);
-	if (response.status !== 200) {
-		// send error
-		base.sendError(context, `Failed to get comic #${num}\n${response.status}: ${response.statusText}`)
-		return;
-	}
-	return response.data;
-}
-
-const xkcd = async (context) => {
-	let receivedMessage = context.message;
-	let args = context.args;
-	const requestedComic = (args[0] || "").trim();
-	let num;
-	receivedMessage.delete();
-	if (!requestedComic) {
-		// latest. It works
-		num = "";
-	}
-	else if (/^\d+$/.test(requestedComic)  && args.length === 1) {
-		num = parseInt(requestedComic);
-    if (num === 404) {
-			receivedMessage.channel.send("Error 404: comic not found");
-			return;
-		}
-	} else if (requestedComic === "random"  && args.length === 1) {
-		const latest = await getXkcdComicInfo("", context);
-		num = Math.floor(Math.random() * (latest.num + 1));
-	} else {
-		return xkcdsearch(context);
-	}
-	const comic = await getXkcdComicInfo(num, context);
-
-	const comicEmbed = new Discord.MessageEmbed()
-		.setColor('#1A73E8')
-		.setTitle(`xkcd #${num}: ${comic.title}`)
-		.setDescription(`Posted on ${comic.month}/${comic.day}/${comic.year}`)
-		.setImage(comic.img)
-		.setURL(`https://xkcd.com/${num}`)
-		.setFooter(comic.alt);
-	receivedMessage.channel.send(comicEmbed);
-}
-
-const xkcdsearch = async (context) => {
-	let receivedMessage = context.message;
-	let args = context.args;
-	const terms = args.join("+");
-	if (!terms) {
-		receivedMessage.channel.send(`You forgot a search term.`);
-		return;
-	}
-	const url = "https://www.explainxkcd.com/wiki/index.php?" + querystring.stringify({
-		search: `${terms}+-incategory:"All Comics"`,
-		title: "Special:Search",
-	});
-	const response = await axios.get(url);
-	if (response.status !== 200) {
-		// send error
-		base.sendError(context, `Failed to search explainxkcd.com for ${terms} #${num}\n${response.status}: ${response.statusText}`)
-		return;
-	}
-	if (/There were no results matching the query/.test(response.data)) {
-		receivedMessage.channel.send("No results");
-		return;
-	}
-	let selector;
-	if (/mw-search-results/.test(response.data)) {
-		// direct comic page
-		selector = "mw-search-results";
-	} else {
-		// search results page
-		selector = `<h1 id="firstHeading" class="firstHeading" lang="en">`;
-	}
-	const htmlToSearch = (response.data.split(selector) || [])[1];
-	if (!htmlToSearch) {
-		receivedMessage.channel.send("No (usable) results");
-		return;
-	}
-	let num = (htmlToSearch.match(/\d+(?=:)/) || [])[0];
-	if (!num) {
-		receivedMessage.channel.send("No (usable) results");
-		return;
-	}
-	num = parseInt(num);
-	const comic = await getXkcdComicInfo(num);
-	const comicEmbed = new Discord.MessageEmbed()
-		.setColor('#1A73E8')
-		.setTitle(`xkcd #${num}: ${comic.title}`)
-		.setDescription(`Posted on ${comic.month}/${comic.day}/${comic.year}`)
-		.setImage(comic.img)
-		.setURL(`https://xkcd.com/${num}`)
-		.setFooter(comic.alt);
-	receivedMessage.channel.send(comicEmbed);
-}
-
 const speak = async (context) => {
 	const config = getConfig(context.message.guild.id, context.nosql);
 	if (!config.administrators.includes(context.message.author.id)) {
@@ -433,7 +333,5 @@ module.exports = {
 	startListening,
 	stopListening,
 	ignoredChannels,
-	xkcd,
-	xkcdsearch,
 	speak
 };

--- a/misc-commands/xkcd.js
+++ b/misc-commands/xkcd.js
@@ -1,0 +1,155 @@
+const querystring = require('querystring');
+const base = require('../base-commands/base');
+const axios = require('axios').default;
+
+async function getXkcdComicInfo(num, context) {
+	if (num !== '') {
+		num = parseInt(num);
+	}
+	const response = await axios.get(`https://xkcd.com/${num}/info.0.json`);
+	if (response.status !== 200) {
+		// send error
+		base.sendError(
+			context,
+			`Failed to get comic #${num}\n${response.status}: ${response.statusText}`
+		);
+		return;
+	}
+	return response.data;
+}
+
+async function xkcd(context) {
+	const { message, args } = context;
+	const requestedComic = (args[0] || '').trim();
+	let num;
+	message.delete();
+	if (!requestedComic) {
+		// latest. It works
+		num = '';
+	} else if (/^\d+$/.test(requestedComic) && args.length === 1) {
+		num = parseInt(requestedComic);
+	} else if (requestedComic === 'random' && args.length === 1) {
+		const latest = await getXkcdComicInfo('', context);
+		num = Math.floor(Math.random() * (latest.num + 1));
+	} else {
+		// first search titles, then text, the scrape the search page
+		const searchFuncs = [
+			(terms) => xkcdApiSearch(terms, 'title'),
+			(terms) => xkcdApiSearch(terms, 'text'),
+			xkcdScrapeSearch
+		];
+		for (const searchFunc of searchFuncs) {
+			const result = await searchFunc(args);
+			if (result == null) {
+				continue;
+			} else if (Number.isInteger(result)) {
+				num = result;
+				break;
+			} else {
+				base.sendError(context, result.toString());
+				return;
+			}
+		}
+		if (!num) {
+			message.channel.send('No results');
+			return;
+		}
+	}
+	if (num === 404) {
+		message.channel.send('Error 404: comic not found');
+		return;
+	}
+	const comic = await getXkcdComicInfo(num, context);
+
+	const comicEmbed = new Discord.MessageEmbed()
+		.setColor('#1A73E8')
+		.setTitle(`xkcd #${comic.num}: ${comic.title}`)
+		.setDescription(`Posted on ${comic.month}/${comic.day}/${comic.year}`)
+		.setImage(comic.img)
+		.setURL(`https://xkcd.com/${num}`)
+		.setFooter(comic.alt);
+	message.channel.send(comicEmbed);
+}
+
+async function xkcdScrapeSearch(args) {
+	if (!args || args.length === 0) {
+		return;
+	}
+	const terms = args
+		.map((a) => a.trim())
+		.filter(Boolean)
+		.join('+');
+	const url =
+		'https://www.explainxkcd.com/wiki/index.php?' +
+		querystring.stringify({
+			search: terms,
+			title: 'Special:Search',
+			printable: 'yes'
+		});
+	const response = await axios.get(url);
+	if (response.status !== 200) {
+		// send error
+		return `Failed to search explainxkcd.com for ${terms} #${num}\n${response.status}: ${response.statusText}`;
+	}
+	if (/There were no results matching the query/.test(response.data)) {
+		return;
+	}
+	let selector;
+	if (/mw-search-results/.test(response.data)) {
+		// direct comic page
+		selector = 'mw-search-results';
+	} else {
+		// search results page
+		selector = `<h1 id="firstHeading" class="firstHeading" lang="en">`;
+	}
+	const htmlToSearch = (response.data.split(selector) || [])[1];
+	if (!htmlToSearch) {
+		return;
+	}
+	const num = (htmlToSearch.match(/\d+(?=:)/) || [])[0];
+	if (!num) {
+		return;
+	}
+	return parseInt(num);
+}
+
+async function xkcdApiSearch(args, whatToSearch) {
+	if (!args || args.length === 0) {
+		return;
+	}
+	const terms = args
+		.map((a) => a.trim())
+		.filter(Boolean)
+		.join('+');
+	const url =
+		'https://www.explainxkcd.com/wiki/api.php?' +
+		querystring.stringify({
+			action: 'query',
+			format: 'json',
+			generator: 'search',
+			gsrnamespace: 0,
+			gsrlimit: 1,
+			gsrwhat: whatToSearch ?? 'text',
+			gsrsearch: terms
+		});
+
+	const response = await axios.get(url);
+	if (response.status !== 200) {
+		// send error
+		return `Failed to search explainxkcd.com for ${terms} #${num}\n${response.status}: ${response.statusText}`;
+	}
+	if (!response.data?.query?.pages) {
+		return;
+	}
+	const title = Object.values(response.data.query.pages)?.[0]?.title;
+	if (!title) {
+		return;
+	}
+	const num = /\d+(?=:)/.exec(title)?.[0];
+	if (!num) {
+		return;
+	}
+	return parseInt(num);
+}
+
+module.exports = { xkcd };


### PR DESCRIPTION
commit 03204ace794a18faef97b8ef4cd327be8be1ffe7
Author: Carter McBride <junk@carter.works>
Date:   Wed Jan 13 21:54:57 2021 -0700

    first search the titles api, then the text api, then scrape the search page

commit 8d015031d14495ecff44dec91fbdf2be19a5a7bc
Author: Carter McBride <junk@carter.works>
Date:   Wed Jan 13 21:34:09 2021 -0700

    search titles and text using the api

commit eb18187f9ee9f75726df6b9dc2350f5b5036dd6c
Author: Carter McBride <junk@carter.works>
Date:   Wed Jan 13 20:47:40 2021 -0700

    remove debug url posting

commit 9962780a3e225d34037cbf68b464bf3a3f24f73b
Author: Carter McBride <junk@carter.works>
Date:   Wed Jan 13 20:39:40 2021 -0700

    improve searching a little bit

commit 69ebb77662d538123891fbd42b61cc0f3192c38d
Author: Carter McBride <junk@carter.works>
Date:   Wed Jan 13 20:31:55 2021 -0700

    make xkcd() a little more stateless

commit d54de205a63c15bafc16b3d39d258ec943ee3519
Author: Carter McBride <junk@carter.works>
Date:   Wed Jan 13 20:27:44 2021 -0700

    always use the api's number

commit 66969ba9697e7426be7c609b5ff55efe2d8f6598
Author: Carter McBride <junk@carter.works>
Date:   Wed Jan 13 20:26:50 2021 -0700

    move xkcd to separate file