### PR TITLE
Never mention @everyone

### DIFF
--- a/kaiser.js
+++ b/kaiser.js
@@ -1,5 +1,9 @@
 global.Discord = require('discord.js');
-global.client = new Discord.Client({ partials: ['MESSAGE', 'CHANNEL', 'REACTION']});
+global.client = new Discord.Client({
+	partials: ['MESSAGE', 'CHANNEL', 'REACTION'],
+	disableMentions: 'everyone'
+});
+
 const security = require('./auth.json');
 
 const misc = require('./misc-commands/misc');


### PR DESCRIPTION
Some users have found ways to make the bot repeat strings that include `@everyone`, and inadvertently pinging the entire server. This change should prevent such exploits from working.

I'm assuming here that the bot never legitimately needs to ping an entire server. Is this not the case?